### PR TITLE
CI: Add TravisCI for code linting with ``flake8``

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# vim ft=yaml
+language: python
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+python:
+  - 3.6
+
+before_install:
+  - python -m pip install --upgrade pip
+  - pip install "flake8<3.0" flake8-putty
+
+script:
+  - flake8 dmriprep

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,9 @@ dmriprep
 .. image:: https://circleci.com/gh/nipreps/dmriprep.svg?style=svg
     :target: https://circleci.com/gh/nipreps/dmriprep
 
+.. image:: https://travis-ci.org/nipreps/dmriprep.svg?branch=master
+    :target: https://travis-ci.org/nipreps/dmriprep
+
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3392201.svg
     :target: https://doi.org/10.5281/zenodo.3392201
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,9 +90,9 @@ parentdir_prefix =
 [flake8]
 max-line-length = 99
 doctests = True
-exclude=*build/
+exclude=*build/,*/_afq/*
 select = C,E,F,W,B,B950
-ignore = N802,N806,W503,E203
+ignore = N802,N806,W504,E203
 putty-ignore =
     */__init__.py : +F401
     docs/conf.py : +E265


### PR DESCRIPTION
Although this doesn't implement #16, it addresses the need for checking code style before merging in changes. This PR is not meant as an alternative to Black, but rather as an easy first step towards more comprehensive linting, while offloading the contributors from setting up anything on their end.