### PR TITLE
MAINT: Add maintenance script to update the changelog, update CHANGES

### DIFF
--- a/.maintenance/update_changes.sh
+++ b/.maintenance/update_changes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Collects the pull-requests since the latest release and
+# aranges them in the CHANGES.rst.txt file.
+#
+# This is a script to be run before releasing a new version.
+#
+# Usage /bin/bash update_changes.sh 1.0.1
+#
+
+# Setting      # $ help set
+set -u         # Treat unset variables as an error when substituting.
+set -x         # Print command traces before executing command.
+
+# Check whether the Upcoming release header is present
+head -1 CHANGES.rst | grep -q Upcoming
+UPCOMING=$?
+if [[ "$UPCOMING" == "0" ]]; then
+    head -n3  CHANGES.rst >> newchanges
+fi
+
+# Elaborate today's release header
+HEADER="$1 ($(date '+%B %d, %Y'))"
+echo $HEADER >> newchanges
+echo $( printf "%${#HEADER}s" | tr " " "=" ) >> newchanges
+
+# Search for PRs since previous release
+git log --grep="Merge pull request" `git describe --tags --abbrev=0`..HEAD --pretty='format:  * %b %s' | sed  's/Merge pull request \#\([^\d]*\)\ from\ .*/(\#\1)/' >> newchanges
+echo "" >> newchanges
+echo "" >> newchanges
+
+# Add back the Upcoming header if it was present
+if [[ "$UPCOMING" == "0" ]]; then
+    tail -n+4 CHANGES.rst >> newchanges
+else
+    cat CHANGES.rst >> newchanges
+fi
+
+# Replace old CHANGES.rst with new file
+mv newchanges CHANGES.rst
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,17 @@
-=======
-History
-=======
+0.2.0 (September 06, 2019)
+==========================
+A first attempt to roll out a release capable of running sMRIPrep for the anatomical processing.
+This release will also serve to exercise the continuous deployment set-up.
 
-0.1.0 (2018-09-06)
-------------------
+0.1.1a0 (September 05, 2019)
+============================
+Testing Zenodo integration.
 
+0.1.1 (September 05, 2019)
+==========================
+Tag to mark the start of a big refactor to adhere to fMRIPrep's principles.
+dMRIPrep will bring the contents of this branch back in as a plugin.
+
+0.1.0 (November 21, 2018)
+=========================
 * First release on GitHub.


### PR DESCRIPTION
* Adds ``.maintenance/update_changes.sh``, which should be executed before release as:
   ```
   bash .maintenance/update_changes.sh 0.2.1
   ```
   (version 0.2.1 should be replaced by the actual version to be released).
* Update `CHANGES.rst` to represent reality.