### PR TITLE
[DOC] Add nipreps developers and year to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 nipreps developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the copyright holder and year in the LICENSE file.

See also [PR #13 on dmriprep-viewer](https://github.com/nipreps/dmriprep-viewer/pull/13).