### PR TITLE
[ENH] - extra bval parsing for number of shells

### DIFF
--- a/dmriprep/utils/tests/test_vectors.py
+++ b/dmriprep/utils/tests/test_vectors.py
@@ -97,4 +97,23 @@ def test_bval_scheme(dipy_test_data):
     bval_scheme = v.BVALScheme(bvals = bvals)
     
     print(bval_scheme)
-    assert True ## just see if if can get here..
+    assert bval_scheme.n_shells == 3 ## just see if if can get here..
+    
+def test_bval_when_only_b0_present():
+    ''' all the weird schemes '''
+    res_a = v.BVALScheme(bvals = np.array([0,0]))
+    print(res_a)
+    assert res_a.n_b0 == 2
+    assert res_a.n_shells == 0
+
+def test_more_complez_bval():
+    bvals_b = [5, 300, 300, 300, 300, 300, 305, 1005, 995, 1000, 1000, 1005, 1000,
+               1000, 1005, 995, 1000, 1005, 5, 995, 1000, 1000, 995, 1005, 995, 1000,
+               995, 995, 2005, 2000, 2005, 2005, 1995, 2000, 2005, 2000, 1995, 2005, 5,
+               1995, 2005, 1995, 1995, 2005, 2005, 1995, 2000, 2000, 2000, 1995, 2000, 2000,
+               2005, 2005, 1995, 2005, 2005, 1990, 1995, 1995, 1995, 2005, 2000, 1990, 2010, 5]
+    res_b = v.BVALScheme(bvals = np.array(bvals_b))
+    print(res_b)
+    assert res_b.n_b0 == 4
+    assert res_b.n_shells == 3
+    

--- a/dmriprep/utils/tests/test_vectors.py
+++ b/dmriprep/utils/tests/test_vectors.py
@@ -89,3 +89,12 @@ def test_corruption(tmpdir, dipy_test_data, monkeypatch):
     # Miscellaneous tests
     with pytest.raises(ValueError):
         dgt.to_filename('path', filetype='mrtrix')
+
+def test_bval_scheme(dipy_test_data):
+    '''basic smoke test'''
+    bvals = dipy_test_data['bvals']
+    
+    bval_scheme = v.BVALScheme(bvals = bvals)
+    
+    print(bval_scheme)
+    assert True ## just see if if can get here..

--- a/dmriprep/utils/vectors.py
+++ b/dmriprep/utils/vectors.py
@@ -4,6 +4,7 @@ from itertools import permutations
 import nibabel as nb
 import numpy as np
 from dipy.core.gradients import round_bvals
+from sklearn.cluster import KMeans
 
 B0_THRESHOLD = 50
 BVEC_NORM_EPSILON = 0.1

--- a/dmriprep/utils/vectors.py
+++ b/dmriprep/utils/vectors.py
@@ -182,29 +182,17 @@ class DiffusionGradientTable:
 class BVALScheme:
     """Data structure for bval scheme."""
     
-    def __init__(self, bvals = None, rasb_file = None, shell_diff_thres = SHELL_DIFF_THRES):
+    def __init__(self, bvals = None, shell_diff_thres = SHELL_DIFF_THRES):
         """
         Parse the available bvals into shells
         
         Parameters
         ----------
-        bvals : str or os.pathlike or numpy.ndarray
-            File path of the b-values.
-        rasb_file : str or os.pathlike
-            File path to a RAS-B gradient table. If rasb_file is provided,
-                then bvecs and bvals will be dismissed.
+        bvals : numpy.ndarray of b-values
         """
-        self._bvals = None
-        self._shell_diff_thres = shell_diff_thres
         
-        if rasb_file is not None:
-            if isinstance(rasb_file, (str, Path)):
-                gradients = np.loadtxt(gradients, skiprows=1)
-                self._bvals = np.squeeze(gradients[..., -1])
-        elif bvals is not None:
-            if isinstance(bvals, (str, Path)):
-                bvals = np.loadtxt(str(bvals)).flatten()
-            self._bvals = np.array(bvals)
+        self._shell_diff_thres = shell_diff_thres
+        self._bvals = np.array(bvals)
             
         self._kclust = self._k_cluster_result()
         


### PR DESCRIPTION
In response to issue #64 and discussion during the hack here is a little addition to the vectors utility that can determine and report on the number of the shells (as well as masks for each shell).  

Currently, it is outside of DiffusionTable because I'm unsure if we want all the methods integrated..
