### PR TITLE
MAINT: Increase minimal nibabel required version to 3.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >=3.5
 install_requires =
     dipy >=1.0.0
     indexed_gzip >=0.8.8
-    nibabel ~= 3.0.0rc1
+    nibabel ~= 3.0.1
     nipype ~= 1.3.1
     niworkflows ~= 1.1.3
     numpy


### PR DESCRIPTION
I think that this should help resolve CI errors in #76,#77, #78, etc.