### PR TITLE
MAINT: Revisions after previous maintenance commit (#83)

### DIFF
--- a/dmriprep/cli/run.py
+++ b/dmriprep/cli/run.py
@@ -111,12 +111,12 @@ a keyword designating a spatial reference, and may be followed by optional, \
 colon-separated parameters. \
 Non-standard spaces imply specific orientations and sampling grids. \
 The default value of this flag (meaning, if the argument is not include in the command line) \
-is ``--output-spaces orig`` - the original space and sampling grid of the original DWI data. \
+is ``--output-spaces run`` - the original space and sampling grid of the original DWI run. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization. To generate no DWI outputs (if that is intended for some reason), \
 use this option without specifying any spatial references. For further details, please check out \
-https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
-                                                        if is_release else 'latest'))
+https://www.nipreps.org/dmriprep/en/%s/spaces.html""" % (currentv.base_version
+                                                         if is_release else 'latest'))
 
     #  ANTs options
     g_ants = parser.add_argument_group('Specific options for ANTs registrations')
@@ -148,6 +148,10 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
         '--fs-license-file', metavar='PATH', type=Path,
         help='Path to FreeSurfer license key file. Get it (for free) by registering'
              ' at https://surfer.nmr.mgh.harvard.edu/registration.html')
+    g_fs.add_argument(
+        '--fs-subjects-dir', metavar='PATH', type=Path,
+        help='Path to existing FreeSurfer subjects directory to reuse. '
+             '(default: OUTPUT_DIR/freesurfer)')
 
     # Surface generation xor
     g_surfs = parser.add_argument_group('Surface preprocessing options')
@@ -422,7 +426,7 @@ def build_workflow(opts, retval):
     output_spaces = opts.output_spaces
     if opts.output_spaces is None:
         from niworkflows.utils.spaces import Reference, SpatialReferences
-        output_spaces = SpatialReferences([Reference("orig", {})])
+        output_spaces = SpatialReferences([Reference("run", {})])
 
     # Set up some instrumental utilities
     run_uuid = '%s_%s' % (strftime('%Y%m%d-%H%M%S'), uuid.uuid4())
@@ -529,6 +533,7 @@ def build_workflow(opts, retval):
         debug=opts.debug,
         force_syn=opts.force_syn,
         freesurfer=opts.run_reconall,
+        fs_subjects_dir=opts.fs_subjects_dir,
         hires=opts.hires,
         ignore=opts.ignore,
         layout=layout,
@@ -536,10 +541,10 @@ def build_workflow(opts, retval):
         low_mem=opts.low_mem,
         omp_nthreads=omp_nthreads,
         output_dir=str(output_dir),
-        output_spaces=output_spaces,
         run_uuid=run_uuid,
         skull_strip_fixed_seed=opts.skull_strip_fixed_seed,
-        skull_strip_template=opts.skull_strip_template,
+        skull_strip_template=opts.skull_strip_template[0],
+        spaces=output_spaces,
         subject_list=subject_list,
         use_syn=opts.use_syn_sdc,
         work_dir=str(work_dir),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 git+https://github.com/AleksandarPetrov/napoleon.git@0dc3f28a309ad602be5f44a9049785a1026451b3#egg=sphinxcontrib-napoleon
 git+https://github.com/rwblair/sphinxcontrib-versioning.git@39b40b0b84bf872fc398feff05344051bbce0f63#egg=sphinxcontrib-versioning
 nbsphinx
-nipype ~= 1.3.1
-niworkflows ~= 1.1.0
+nipype ~= 1.4.2
+niworkflows ~= 1.1.9
 packaging
 pydot>=1.2.3
 pydotplus
-smriprep ~= 0.4.1
+smriprep ~= 0.5.2
 sphinx-argparse
 sphinx>=2.1.2
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     dipy >=1.0.0
     indexed_gzip >=0.8.8
     nibabel ~= 3.0
-    nipype ~= 1.4.0
+    nipype ~= 1.4.2
     niworkflows ~= 1.1.9
     numpy
     pybids ~= 0.9.4


### PR DESCRIPTION
Revise #83 and fix the two outstanding issues:
- [x] Outdated `requirements.txt` file when generating docs.
- [x] Inconsistent handling of the `--output-spaces` section, as a result of copy&paste from fMRIPrep.