### PR TITLE
FIX/MAINT: Drop Python 3.6 + Revise Python environment (versions pinned) in Dockerfile

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip: ["pip~=18.1", "pip>=20.3"]
-        setuptools: ["setuptools==40.8.0", "setuptools"]
         
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -48,7 +47,7 @@ jobs:
       run: |
         python -m venv /tmp/install_sdist
         source /tmp/install_sdist/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install "${{ matrix.pip }}" setuptools
         python -m pip install dist/dmriprep*.tar.gz
         INSTALLED_VERSION=$(python -c 'import dmriprep; print(dmriprep.__version__, end="")')
         echo "VERSION: \"${THISVERSION}\""
@@ -58,7 +57,7 @@ jobs:
       run: |
         python -m venv /tmp/install_wheel
         source /tmp/install_wheel/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install "${{ matrix.pip }}" setuptools
         python -m pip install dist/dmriprep*.whl
         INSTALLED_VERSION=$(python -c 'import dmriprep; print(dmriprep.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
@@ -67,7 +66,7 @@ jobs:
       run: |
         python -m venv /tmp/setup_install
         source /tmp/setup_install/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install "${{ matrix.pip }}" setuptools
         python -m pip install numpy scipy "Cython >= 0.28.5" # sklearn needs this
         python -m pip install scikit-learn  # otherwise it attempts to build it
         python setup.py install
@@ -78,13 +77,9 @@ jobs:
       run: |
         python -m venv /tmp/setup_develop
         source /tmp/setup_develop/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install "${{ matrix.pip }}" setuptools
         # sklearn needs these dependencies
-        if [ "${{ matrix.python-version }}" == "3.6" ]; then
-            python -m pip install "numpy < 1.20" scipy "Cython >= 0.28.5"  # numpy 1.20 drops Py3.6
-        else
-            python -m pip install numpy scipy "Cython >= 0.28.5"
-        fi
+        python -m pip install numpy scipy "Cython >= 0.28.5"
         python -m pip install scikit-learn  # otherwise it attempts to build it
         python setup.py develop
         INSTALLED_VERSION=$(python -c 'import dmriprep; print(dmriprep.__version__, end="")')

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,18 +129,18 @@ ENV PATH="/usr/local/miniconda/bin:$PATH" \
     PYTHONNOUSERSITE=1
 
 # Installing precomputed python packages
-RUN conda install -y python=3.7.1 \
-                     pip=19.1 \
-                     mkl=2018.0.3 \
-                     mkl-service \
-                     numpy=1.15.4 \
-                     scipy=1.1.0 \
-                     scikit-learn=0.19.1 \
-                     matplotlib=2.2.2 \
-                     pandas=0.23.4 \
+RUN conda install -y python=3.7 \
+                     graphviz=2.40 \
                      libxml2=2.9.8 \
                      libxslt=1.1.32 \
-                     graphviz=2.40.1 \
+                     matplotlib=2.2 \
+                     mkl \
+                     mkl-service \
+                     numpy=1.19 \
+                     pip=20.3 \
+                     setuptools \
+                     scikit-learn=0.19 \
+                     scipy=1.5 \
                      traits=4.6.0 \
                      zlib; sync && \
     chmod -R a+rX /usr/local/miniconda; sync && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 description = dMRIPrep is a robust and easy-to-use pipeline for preprocessing of diverse dMRI data.
 license = Apache License, Version 2.0
 long_description = file:README.rst
@@ -19,12 +19,12 @@ project_urls =
     Documentation = https://www.nipreps.org/dmriprep
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     dipy >=1.0.0
     indexed_gzip >=0.8.8
     nibabel ~= 3.0
-    nipype ~= 1.5.1
+    nipype >= 1.5.1, < 2.0
     niworkflows >= 1.4.0rc0, <1.5
     numpy
     pybids >= 0.11.1


### PR DESCRIPTION
Dropping Python 3.6 follows suit with Numpy 1.20 and, in principle, *dMRIPrep* will
continue to follow their python support schedule.

Resolves: #145.