### PR TITLE
FIX: typo in omp_threads

### DIFF
--- a/dmriprep/cli/parser.py
+++ b/dmriprep/cli/parser.py
@@ -461,7 +461,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
         build_log.warning(
             "Per-process threads (--omp-nthreads=%d) exceed total "
             "threads (--nthreads/--n_cpus=%d)",
-            config.nipype.omp_nthread,
+            config.nipype.omp_nthreads,
             config.nipype.nprocs,
         )
 


### PR DESCRIPTION
That typo was leading to the error 

`AttributeError: type object 'nipype' has no attribute 'omp_nthread'`
