### PR TITLE
DOC: Fix non-standard `napoleon` custom section mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,10 @@ extensions = [
     "sphinxcontrib.apidoc",
     "nipype.sphinxext.plot_workflow",
     "nipype.sphinxext.apidoc",
+    "numpydoc",
 ]
+numpydoc_show_class_members = False
+autodoc_typehints = "none"
 
 autodoc_mock_imports = [
     "dipy",
@@ -67,11 +70,11 @@ autodoc_mock_imports = [
 # https://github.com/sphinx-contrib/napoleon/pull/10 is merged.
 napoleon_use_param = False
 napoleon_custom_sections = [
-    ("Inputs", "Parameters"),
-    ("Outputs", "Parameters"),
-    ("Attributes", "Parameters"),
-    ("Mandatory Inputs", "Parameters"),
-    ("Optional Inputs", "Parameters"),
+    ("Inputs", "params_style"),
+    ("Outputs", "returns_style"),
+    ("Attributes", "Attributes"),
+    ("Mandatory Inputs", "params_style"),
+    ("Optional Inputs", "params_style"),
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fix non-standard `napoleon` custom section mapping:
- Map `Inputs` and `Outputs` to `params_style` and `returns_style`, respectively, instead of mapping them to `Parameters`.
- Map `Mandatory Inputs` and `Optional Inputs` to `params_style`, instead of mapping them to `Parameters`.
- Add the `numpydoc` extension and set the `numpy_doc_show_class_members` and `autodoc_typehints` flags so that the `Attributes` docstrings are shown.
- Map the `Attributes` section to the `Attributes` string in order to show that value instead of `Variables` in the corresponding documentation section.

Documentation:
https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#confval-napoleon_custom_sections https://stackoverflow.com/questions/72220924/sphinx-how-to-show-attributes-as-in-scipy