### PR TITLE
STY: Make use of f-strings extensive

### DIFF
--- a/.maint/paper_author_list.py
+++ b/.maint/paper_author_list.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     aff_indexes = [
         ", ".join(
             [
-                "%d" % (affiliations.index(a) + 1)
+                f"{affiliations.index(a) + 1}"
                 for a in _aslist(author.get("affiliation", "Unaffiliated"))
             ]
         )
@@ -51,20 +51,11 @@ if __name__ == "__main__":
             file=sys.stderr,
         )
 
-    print("Authors (%d):" % len(hits))
-    print(
-        "%s."
-        % "; ".join(
-            [
-                "%s \\ :sup:`%s`\\ " % (i["name"], idx)
-                for i, idx in zip(hits, aff_indexes)
-            ]
-        )
+    print(f"Authors ({len(hits)}):")
+    authors = "; ".join(
+        f"{i['name']} \\ :sup:`{idx}`\\ " for i, idx in zip(hits, aff_indexes)
     )
+    print(f"{authors}.")
 
-    print(
-        "\n\nAffiliations:\n%s"
-        % "\n".join(
-            ["{0: >2}. {1}".format(i + 1, a) for i, a in enumerate(affiliations)]
-        )
-    )
+    lines = '\n'.join(f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations))
+    print(f'\n\nAffiliations:\n{lines}')

--- a/.maint/update_zenodo.py
+++ b/.maint/update_zenodo.py
@@ -82,11 +82,11 @@ def get_git_lines(fname="line-contributors.txt"):
 
     if not lines:
         raise RuntimeError(
-            """\
-Could not find line-contributors from git repository.%s"""
-            % """ \
-git-line-summary not found, please install git-extras. """
-            * (git_line_summary_path is None)
+            f"""\
+Could not find line-contributors from git repository.{
+                ' git-line-summary not found, please install git-extras.'
+                * (git_line_summary_path is None)
+            }"""
         )
     return [" ".join(line.strip().split()[1:-1]) for line in lines if "%" in line]
 
@@ -114,11 +114,10 @@ if __name__ == "__main__":
     zenodo["creators"] = zen_creators
     zenodo["contributors"] = zen_contributors
 
-    misses = set(miss_creators).intersection(miss_contributors)
-    if misses:
+    missing = {*miss_creators} & {*miss_contributors}
+    if missing:
         print(
-            "Some people made commits, but are missing in .maint/ "
-            f"files: {', '.join(misses)}",
+            f'Some people made commits, but are missing in .maint/ files: {", ".join(sorted(missing))}.',
             file=sys.stderr,
         )
 
@@ -134,4 +133,4 @@ if __name__ == "__main__":
         if isinstance(creator["affiliation"], list):
             creator["affiliation"] = creator["affiliation"][0]
 
-    zenodo_file.write_text("%s\n" % json.dumps(zenodo, indent=2))
+    zenodo_file.write_text(f"{json.dumps(zenodo, indent=2)}\n")

--- a/dmriprep/__about__.py
+++ b/dmriprep/__about__.py
@@ -34,8 +34,6 @@ __credits__ = (
 )
 __url__ = "https://github.com/nipreps/dmriprep"
 
-DOWNLOAD_URL = "https://github.com/nipreps/{name}/archive/{ver}.tar.gz".format(
-    name=__packagename__, ver=__version__
-)
+DOWNLOAD_URL = f"https://github.com/nipreps/{__packagename__}/archive/{__version__}.tar.gz"
 
 __ga_id__ = "UA-156165436-1"

--- a/dmriprep/_version.py
+++ b/dmriprep/_version.py
@@ -86,20 +86,20 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % dispcmd)
+                print(f"unable to run {dispcmd}")
                 print(e)
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(f"unable to run {dispcmd} (error)")
+            print(f"stdout was {stdout}")
         return None, p.returncode
     return stdout, p.returncode
 
@@ -124,8 +124,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(f"Tried directories {rootdirs} but none started with prefix {parentdir_prefix}")
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -192,15 +191,15 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs - tags))
+            print(f"discarding '{','.join(refs - tags)}', no digits")
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):
         # sorting will prefer e.g., "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
             if verbose:
-                print("picking %s" % r)
+                print(f"picking {r}")
             return {"version": r,
                     "full-revisionid": keywords["full"].strip(),
                     "dirty": False, "error": None,
@@ -229,14 +228,14 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
                           hide_stderr=True)
     if rc != 0:
         if verbose:
-            print("Directory %s not under git control" % root)
+            print(f"Directory {root} not under git control")
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
                                           "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
+                                          "--match", f"{tag_prefix}*"],
                                    cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:
@@ -269,18 +268,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = f"unable to parse git-describe output: '{describe_out}'"
             return pieces
 
         # tag
         full_tag = mo.group(1)
         if not full_tag.startswith(tag_prefix):
             if verbose:
-                fmt = "tag '%s' doesn't start with prefix '%s'"
-                print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+                print(
+                    f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'")
+            pieces["error"] = (f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix):]
 
@@ -370,13 +367,13 @@ def render_pep440_post(pieces):
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += "g%s" % pieces["short"]
+            rendered += f"g{pieces['short']}"
     else:
         # exception #1
         rendered = "0.post%d" % pieces["distance"]
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += "+g%s" % pieces["short"]
+        rendered += f"+g{pieces['short']}"
     return rendered
 
 
@@ -467,7 +464,7 @@ def render(pieces, style):
     elif style == "git-describe-long":
         rendered = render_git_describe_long(pieces)
     else:
-        raise ValueError("unknown style '%s'" % style)
+        raise ValueError(f"unknown style '{style}'")
 
     return {"version": rendered, "full-revisionid": pieces["long"],
             "dirty": pieces["dirty"], "error": None,

--- a/dmriprep/cli/parser.py
+++ b/dmriprep/cli/parser.py
@@ -74,9 +74,7 @@ def _build_parser():
     )
 
     parser = ArgumentParser(
-        description="dMRIPrep: dMRI PREProcessing workflows v{}".format(
-            config.environment.version
-        ),
+        description=f"dMRIPrep: dMRI PREProcessing workflows v{config.environment.version}",
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     PathExists = partial(_path_exists, parser=parser)
@@ -224,7 +222,7 @@ def _build_parser():
         "--output-spaces",
         nargs="*",
         action=OutputReferencesAction,
-        help="""\
+        help=f"""\
 Standard and non-standard spaces to resample anatomical and diffusion images to. \
 Standard spaces may be specified by the form \
 ``<SPACE>[:cohort-<label>][:res-<resolution>][...]``, where ``<SPACE>`` is \
@@ -236,8 +234,7 @@ is ``--output-spaces run`` - the original space and sampling grid of the origina
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization. To generate no DWI outputs (if that is intended for some reason), \
 use this option without specifying any spatial references. For further details, please check out \
-https://www.nipreps.org/dmriprep/en/%s/spaces.html"""
-        % (currentv.base_version if is_release else "latest"),
+https://www.nipreps.org/dmriprep/en/{currentv.base_version if is_release else "latest"}/spaces.html"""
     )
     g_conf.add_argument(
         "--dwi2t1w-init",
@@ -388,11 +385,10 @@ is discouraged.""",
     latest = check_latest()
     if latest is not None and currentv < latest:
         print(
-            """\
-You are using dMRIPrep-%s, and a newer version of dMRIPrep is available: %s.
+            f"""\
+You are using dMRIPrep-{currentv}, and a newer version of dMRIPrep is available: {latest}.
 Please check out our documentation about how and when to upgrade:
-https://dmriprep.readthedocs.io/en/latest/faq.html#upgrading"""
-            % (currentv, latest),
+https://dmriprep.readthedocs.io/en/latest/faq.html#upgrading""",
             file=sys.stderr,
         )
 
@@ -400,12 +396,11 @@ https://dmriprep.readthedocs.io/en/latest/faq.html#upgrading"""
     if _blist[0]:
         _reason = _blist[1] or "unknown"
         print(
-            """\
-WARNING: Version %s of dMRIPrep (current) has been FLAGGED
-(reason: %s).
+            f"""\
+WARNING: Version {config.environment.version} of dMRIPrep (current) has been FLAGGED
+(reason: {_reason}).
 That means some severe flaw was found in it and we strongly
-discourage its usage."""
-            % (config.environment.version, _reason),
+discourage its usage.""",
             file=sys.stderr,
         )
 
@@ -459,10 +454,8 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     # This may need to be revisited if people try to use batch plugins
     if 1 < config.nipype.nprocs < config.nipype.omp_nthreads:
         build_log.warning(
-            "Per-process threads (--omp-nthreads=%d) exceed total "
-            "threads (--nthreads/--n_cpus=%d)",
-            config.nipype.omp_nthreads,
-            config.nipype.nprocs,
+            f"Per-process threads (--omp-nthreads={config.nipype.omp_nthreads}) exceed total "
+            f"threads (--nthreads/--n_cpus={config.nipype.nprocs})",
         )
 
     bids_dir = config.execution.bids_dir
@@ -477,20 +470,18 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     if opts.clean_workdir and work_dir.exists():
         from niworkflows.utils.misc import clean_directory
 
-        build_log.log("Clearing previous dMRIPrep working directory: %s", work_dir)
+        build_log.log(f"Clearing previous dMRIPrep working directory: {work_dir}")
         if not clean_directory(work_dir):
             build_log.warning(
-                "Could not clear all contents of working directory: %s", work_dir
+                f"Could not clear all contents of working directory: {work_dir}"
             )
 
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:
+        ver = version.split("+")[0]
         parser.error(
             "The selected output folder is the same as the input BIDS folder. "
-            "Please modify the output path (suggestion: %s)."
-            % bids_dir
-            / "derivatives"
-            / ("dmriprep-%s" % version.split("+")[0])
+            f'Please modify the output path (suggestion: {bids_dir / 'derivatives' / f'dmriprep-{ver}'}).'
         )
 
     if bids_dir in work_dir.parents:
@@ -529,7 +520,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     if missing_subjects:
         parser.error(
             "One or more participant labels were not found in the BIDS directory: "
-            "%s." % ", ".join(missing_subjects)
+            f"{', '.join(missing_subjects)}."
         )
 
     config.execution.participant_label = sorted(participant_label)

--- a/dmriprep/cli/run.py
+++ b/dmriprep/cli/run.py
@@ -103,7 +103,7 @@ def main():
     config.loggers.workflow.log(
         15,
         "\n".join(
-            ["dMRIPrep config:"] + ["\t\t%s" % s for s in config.dumps().splitlines()]
+            ["dMRIPrep config:"] + [f"\t\t{s}" for s in config.dumps().splitlines()]
         ),
     )
     config.loggers.workflow.log(25, "dMRIPrep started!")
@@ -113,7 +113,7 @@ def main():
     except Exception as e:
         if not config.execution.notrack:
             popylar.track_event(__ga_id__, "run", "error")
-        config.loggers.workflow.critical("dMRIPrep failed: %s", e)
+        config.loggers.workflow.critical(f"dMRIPrep failed: {e}")
         raise
     else:
         config.loggers.workflow.log(25, "dMRIPrep finished successfully!")

--- a/dmriprep/cli/tests/test_parser.py
+++ b/dmriprep/cli/tests/test_parser.py
@@ -109,13 +109,10 @@ def test_get_parser_update(monkeypatch, capsys, current, latest):
     _build_parser()
     captured = capsys.readouterr().err
 
-    msg = """\
-You are using dMRIPrep-%s, and a newer version of dMRIPrep is available: %s.
+    msg = f"""\
+You are using dMRIPrep-{current}, and a newer version of dMRIPrep is available: {latest}.
 Please check out our documentation about how and when to upgrade:
-https://dmriprep.readthedocs.io/en/latest/faq.html#upgrading""" % (
-        current,
-        latest,
-    )
+https://dmriprep.readthedocs.io/en/latest/faq.html#upgrading"""
 
     assert (msg in captured) is expectation
 

--- a/dmriprep/cli/version.py
+++ b/dmriprep/cli/version.py
@@ -74,7 +74,7 @@ def check_latest():
     if latest is not None:
         try:
             cachefile.write_text(
-                "|".join(("%s" % latest, datetime.now().strftime(DATE_FMT)))
+                "|".join((f"{latest}", datetime.now().strftime(DATE_FMT)))
             )
         except Exception:
             pass

--- a/dmriprep/config/__init__.py
+++ b/dmriprep/config/__init__.py
@@ -105,7 +105,7 @@ finally:
 def redirect_warnings(message, category, filename, lineno, file=None, line=None):
     """Redirect other warnings."""
     logger = logging.getLogger()
-    logger.debug("Captured warning (%s): %s", category, message)
+    logger.debug(f"Captured warning ({category}): {message}")
 
 
 warnings.showwarning = redirect_warnings
@@ -161,9 +161,7 @@ try:
                 _oc_limit in ("0", "n/a")
                 and Path("/proc/sys/vm/overcommit_ratio").exists()
             ):
-                _oc_limit = "{}%".format(
-                    Path("/proc/sys/vm/overcommit_ratio").read_text().strip()
-                )
+                _oc_limit = f"{Path('/proc/sys/vm/overcommit_ratio').read_text().strip()}%"
 except Exception:
     pass
 
@@ -364,7 +362,7 @@ class execution(_Config):
     the command line) as spatial references for outputs."""
     reports_only = False
     """Only build the reports, based on the reportlets found in a cached working directory."""
-    run_uuid = "%s_%s" % (strftime("%Y%m%d-%H%M%S"), uuid4())
+    run_uuid = f'{strftime("%Y%m%d-%H%M%S")}_{uuid4()}'
     """Unique identifier of this particular run."""
     participant_label = None
     """List of participant identifiers that are to be preprocessed."""

--- a/dmriprep/interfaces/__init__.py
+++ b/dmriprep/interfaces/__init__.py
@@ -39,20 +39,18 @@ class BIDSDataGrabber(SimpleInterface):
 
         if not bids_dict["t1w"]:
             raise FileNotFoundError(
-                "No T1w images found for subject sub-{}".format(self.inputs.subject_id)
+                f"No T1w images found for subject sub-{self.inputs.subject_id}"
             )
 
         if self._require_dwis and not bids_dict["dwi"]:
             raise FileNotFoundError(
-                "No diffusion weighted images found for subject sub-{}".format(
-                    self.inputs.subject_id
-                )
+                f"No diffusion weighted images found for subject sub-{self.inputs.subject_id}"
             )
 
         for imtype in ["dwi", "t2w", "flair", "fmap", "roi"]:
             if not bids_dict[imtype]:
                 _LOGGER.warning(
-                    'No "%s" images found for sub-%s', imtype, self.inputs.subject_id
+                    f'No "{imtype}" images found for sub-{self.inputs.subject_id}'
                 )
 
         return runtime

--- a/dmriprep/interfaces/reports.py
+++ b/dmriprep/interfaces/reports.py
@@ -123,7 +123,7 @@ class SubjectSummary(SummaryInterface):
 
         t2w_seg = ""
         if self.inputs.t2w:
-            t2w_seg = "(+ {:d} T2-weighted)".format(len(self.inputs.t2w))
+            t2w_seg = f"(+ {len(self.inputs.t2w)} T2-weighted)"
 
         dwi_files = self.inputs.dwi if isdefined(self.inputs.dwi) else []
         dwi_files = [s[0] if isinstance(s, list) else s for s in dwi_files]

--- a/dmriprep/interfaces/vectors.py
+++ b/dmriprep/interfaces/vectors.py
@@ -114,7 +114,7 @@ class CheckGradientTable(SimpleInterface):
             )
             table.to_filename(rasb_file)
         self._results["out_rasb"] = rasb_file
-        table.to_filename("%s/dwi" % cwd, filetype="fsl")
+        table.to_filename(f"{cwd}/dwi", filetype="fsl")
         self._results["out_bval"] = str(cwd / "dwi.bval")
         self._results["out_bvec"] = str(cwd / "dwi.bvec")
         return runtime

--- a/dmriprep/utils/bids.py
+++ b/dmriprep/utils/bids.py
@@ -96,7 +96,7 @@ def write_derivative_description(bids_dir, deriv_dir):
 
     if "DatasetDOI" in orig_desc:
         desc["SourceDatasetsURLs"] = [
-            "https://doi.org/{}".format(orig_desc["DatasetDOI"])
+            f"https://doi.org/{orig_desc['DatasetDOI']}"
         ]
     if "License" in orig_desc:
         desc["License"] = orig_desc["License"]
@@ -183,7 +183,7 @@ def validate_input_dir(exec_env, bids_dir, participant_label):
         ignored_subs = all_subs.difference(selected_subs)
         if ignored_subs:
             for sub in ignored_subs:
-                validator_config_dict["ignoredFiles"].append("/sub-%s/**" % sub)
+                validator_config_dict["ignoredFiles"].append(f"/sub-{sub}/**")
     with tempfile.NamedTemporaryFile("w+") as temp:
         temp.write(json.dumps(validator_config_dict))
         temp.flush()

--- a/dmriprep/utils/vectors.py
+++ b/dmriprep/utils/vectors.py
@@ -295,10 +295,10 @@ class DiffusionGradientTable:
             )
         elif filetype.lower() == "fsl":
             self.generate_vecval()
-            np.savetxt("%s.bvec" % filename, self.bvecs.T, fmt="%.6f")
-            np.savetxt("%s.bval" % filename, self.bvals, fmt="%.6f")
+            np.savetxt(f"{filename}.bvec", self.bvecs.T, fmt="%.6f")
+            np.savetxt(f"{filename}.bval", self.bvals, fmt="%.6f")
         else:
-            raise ValueError('Unknown filetype "%s"' % filetype)
+            raise ValueError(f'Unknown filetype "{filetype}"')
 
 
 def normalize_gradients(


### PR DESCRIPTION
Make use of f-strings extensive: prefer using f-strings for string interpolation and formatting instead of the modulo operator and the `str.format()` method.

f-strings have become the preferred method for Python string formatting since their introduction in Python 3.6:
https://peps.python.org/pep-0498/

The code becomes more concise and readable.